### PR TITLE
Fix invalid host IP address

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -51,7 +51,7 @@ services:
     entrypoint: ["/usr/src/app/packages/app-config/start_dev_hub.sh"]
     userns_mode: keep-id:uid=1001
     extra_hosts:
-      - "gitea:localhost"
+      - "gitea:127.0.0.1"
     environment:
       - PORT=3001
       - APP_CONFIG=/usr/src/app/packages/app-config/app-config.yaml


### PR DESCRIPTION
`podman compose up` was throwing an error `Error: invalid IP address in add-host: "localhost"` when trying to start the `developer-hub` container.